### PR TITLE
Add FlutterSaveLocation to exported classes of redux_persist_flutter.…

### DIFF
--- a/packages/redux_persist_flutter/lib/redux_persist_flutter.dart
+++ b/packages/redux_persist_flutter/lib/redux_persist_flutter.dart
@@ -2,4 +2,4 @@ library redux_persist_flutter;
 
 export 'src/gate.dart' show PersistorGate;
 export 'src/storage.dart'
-    show FlutterStorage, DocumentFileEngine, SharedPreferencesEngine;
+    show FlutterStorage, FlutterSaveLocation, DocumentFileEngine, SharedPreferencesEngine;


### PR DESCRIPTION
As discussed in issue #8 (Undefined name 'FlutterSaveLocation')